### PR TITLE
Pointer's scale is not updated after changing Tink scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,5 +405,10 @@ let t = new Tink(PIXI, renderer.view, scale);
 ```
 This will ensure that the coordinates that Tink uses will match the canvas's scaled pixel coordinates.
 
-
-
+Finally, make sure to update the Tink scale if you also opted for rescaling the canvas element every time the size of the browser window has changed:
+```js
+window.addEventListener("resize", function(event){ 
+  let scale = scaleToWindow(anyCanvasElement);
+  t.scale(scale)
+});
+```

--- a/src/tink.js
+++ b/src/tink.js
@@ -1,8 +1,7 @@
 class Tink {
   constructor(PIXI, element, scale = 1) {
 
-    console.log(element)
-      //Add element and scale properties
+    //Add element and scale properties
     this.element = element;
     this.scale = scale;
 

--- a/src/tink.js
+++ b/src/tink.js
@@ -3,7 +3,7 @@ class Tink {
 
     //Add element and scale properties
     this.element = element;
-    this.scale = scale;
+    this._scale = scale;
 
     //An array to store all the draggable sprites
     this.draggableSprites = [];
@@ -23,6 +23,17 @@ class Tink {
     this.TextureCache = this.PIXI.utils.TextureCache;
     this.AnimatedSprite = this.PIXI.extras.AnimatedSprite;
     this.Texture = this.PIXI.Texture;
+  }
+
+  get scale() {
+    return this._scale;
+  }
+
+  set scale(value) {
+    this._scale = value;
+
+    //Update scale values for all pointers
+    this.pointers.forEach(pointer => pointer.scale = value);
   }
 
   //`makeDraggable` lets you make a drag-and-drop sprite by pushing it


### PR DESCRIPTION
The documentation mentions that [it's possible for Tink to work with scaleToWindow](https://github.com/kittykatattack/tink#scale), however it does not work completely when one opts to resize the canvas element each time the browser window has been resized. This is because the pointers are never updated to reflect the new scale. 

This pull request makes the `scale` property of `Tink` public by introducing regular getter and setter that updates the pointers accordingly.